### PR TITLE
Let attempt->/->> macros check their first argument for failure

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -14,7 +14,7 @@
 (bootlaces! +version+)
 
 (task-options!
-  pom {:project        'failjure
+  pom {:project        'org.clojars.sherpc/failjure
        :version        +version+
        :description    "Simple helpers for treating failures as values"
        :url            "https://github.com/flocktory/failjure"

--- a/build.boot
+++ b/build.boot
@@ -10,15 +10,15 @@
 (require '[adzerk.bootlaces :refer :all]
          '[adzerk.boot-test :refer :all])
 
-(def +version+ "0.1.4")
+(def +version+ "0.1.5")
 (bootlaces! +version+)
 
 (task-options!
   pom {:project        'failjure
        :version        +version+
        :description    "Simple helpers for treating failures as values"
-       :url            "https://github.com/adambard/failjure"
-       :scm            {:url "https://github.com/adambard/failjure"}
+       :url            "https://github.com/flocktory/failjure"
+       :scm            {:url "https://github.com/flocktory/failjure"}
        :license        {"Eclipse Public License" "http://www.eclipse.org/legal/epl-v10.html"}})
 
 (deftask deploy-clojars []

--- a/build.boot
+++ b/build.boot
@@ -10,15 +10,15 @@
 (require '[adzerk.bootlaces :refer :all]
          '[adzerk.boot-test :refer :all])
 
-(def +version+ "0.1.5")
+(def +version+ "0.1.4")
 (bootlaces! +version+)
 
 (task-options!
-  pom {:project        'org.clojars.sherpc/failjure
+  pom {:project        'failjure
        :version        +version+
        :description    "Simple helpers for treating failures as values"
-       :url            "https://github.com/flocktory/failjure"
-       :scm            {:url "https://github.com/flocktory/failjure"}
+       :url            "https://github.com/adambard/failjure"
+       :scm            {:url "https://github.com/adambard/failjure"}
        :license        {"Eclipse Public License" "http://www.eclipse.org/legal/epl-v10.html"}})
 
 (deftask deploy-clojars []

--- a/src/failjure/core.clj
+++ b/src/failjure/core.clj
@@ -1,6 +1,5 @@
 (ns failjure.core
-  (:require [clojure.algo.monads :refer [domonad defmonad]]
-            [failjure.core :as f]))
+  (:require [clojure.algo.monads :refer [domonad defmonad]]))
 
 ; Public API
 ; failed?, message part of prototype

--- a/src/failjure/core.clj
+++ b/src/failjure/core.clj
@@ -1,5 +1,6 @@
 (ns failjure.core
-  (:require [clojure.algo.monads :refer [domonad defmonad]]))
+  (:require [clojure.algo.monads :refer [domonad defmonad]]
+            [failjure.core :as f]))
 
 ; Public API
 ; failed?, message part of prototype
@@ -95,17 +96,22 @@
 
 (defmacro attempt->
   ([start] start)
-  ([start form] `(domonad error-m [x# (-> ~start ~form)] x#))
+  ([start form]
+   `(if (failed? ~start)
+      ~start
+      (domonad error-m [x# (-> ~start ~form)] x#)))
   ([start form & forms]
    `(let [new-start# (attempt-> ~start ~form)]
       (if (failed? new-start#)
         new-start#
         (attempt-> new-start# ~@forms)))))
 
-
 (defmacro attempt->>
   ([start] start)
-  ([start form] `(domonad error-m [x# (->> ~start ~form)] x#))
+  ([start form]
+   `(if (failed? ~start)
+      ~start
+      (domonad error-m [x# (->> ~start ~form)] x#)))
   ([start form & forms]
    `(let [new-start# (attempt->> ~start ~form)]
       (if (failed? new-start#)

--- a/test/failjure/test_core.clj
+++ b/test/failjure/test_core.clj
@@ -63,7 +63,7 @@
             ""
             (str "O")
             (str "k")
-            (str "!")))) 
+            (str "!"))))
 
       (is (= (fail "Not OK!")
              (attempt->
@@ -71,7 +71,15 @@
                (str "Not OK!")
                (fail)
                (str "kay-O!")
-               (reverse)))))
+               (reverse))))
+
+      (is (= (fail "Not OK!")
+             (attempt->
+              (fail "Not OK!")
+              (str "Not OK!")
+              (fail)
+              (str "kay-O!")
+              (reverse)))))
 
     ; Test attempt->>
     (testing "attempt->>"
@@ -79,7 +87,7 @@
           (attempt->>
             ""
             (str "k")
-            (str "O")))) 
+            (str "O"))))
 
       (is (= (fail "Not OK!")
              (attempt->>
@@ -87,7 +95,15 @@
                (str "Not OK!")
                (fail)
                (str "O")
-               (reverse)))))
+               (reverse))))
+
+      (is (= (fail "Not OK!")
+             (attempt->>
+              (fail "Not OK!")
+              (str "Not OK!")
+              (fail)
+              (str "O")
+              (reverse)))))
     
     (testing "failed?"
       (testing "failed? is valid on nullable"


### PR DESCRIPTION
Example usage:

```
(defn might-return-failure [] ...)

(let [x (might-return-failure)]
  ;; In old version we have exception here, but in new one we just return failure
  (attempt->
   x
   inc))
```