### PR TITLE
Fix #33, spurious clj-kondo warning

### DIFF
--- a/resources/clj-kondo.exports/adambard/failjure/config.edn
+++ b/resources/clj-kondo.exports/adambard/failjure/config.edn
@@ -1,7 +1,6 @@
 {:lint-as {failjure.core/ok->             clojure.core/->
            failjure.core/ok->>            clojure.core/->>
            failjure.core/try-all          clojure.core/let
-           failjure.core/try*             clojure.core/try
            failjure.core/when-failed      clojure.core/fn
            failjure.core/if-failed        clojure.core/fn
            failjure.core/attempt-all      clojure.core/let


### PR DESCRIPTION
As seen in https://github.com/adambard/failjure/issues/33, there's extra config that causing problems.